### PR TITLE
fix encoding error for windows

### DIFF
--- a/dwdweather/__init__.py
+++ b/dwdweather/__init__.py
@@ -1,5 +1,5 @@
 """dwdweather2: Python client to access weather data from Deutscher Wetterdienst (DWD)."""
 __appname__ = 'dwdweather2'
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 from .core import DwdWeather

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ import os
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.rst')).read()
+README = open(os.path.join(here, 'README.rst'), encoding='UTF-8').read()
 
 setup(name='dwdweather2',
-      version='0.8.0',
+      version='0.8.1',
       description='Python client to access weather data from Deutscher Wetterdienst (DWD), '
                   'the federal meteorological service in Germany.',
       long_description=README,


### PR DESCRIPTION
On windows installation python may assume a limited encoding such as `cp1252`. That leads to encoding errors when installing on windows command line, because the `README.rst` is parsed which as a modern encoding.

This pull requests sets the encoding of the README.rst to `UTF-8`.

Be aware, that I set a new version `0.8.1`, Check, if you want to accept that.