### PR TITLE
Fix Class Init Issue and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 .mypy_cache/
+.vscode/
+.pytest_cache/
+
 *.py[cod]
 
 # C extensions

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+.mypy_cache/
 *.py[cod]
 
 # C extensions

--- a/dwdweather/core.py
+++ b/dwdweather/core.py
@@ -44,7 +44,7 @@ class DwdWeather:
     # Observations in Germany.
     germany_climate_uri = baseuri + '/observations_germany/climate/{resolution}'
 
-    def __init__(self, resolution=None, category_names=None, **kwargs):
+    def __init__(self, resolution="hourly", category_names=None, **kwargs):
 
         # =================
         # Configure context

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = --verbose --log-cli-level=DEBUG
+
+# https://docs.pytest.org/en/latest/warnings.html
+filterwarnings =
+    ignore::DeprecationWarning

--- a/tests/test_dwdweather.py
+++ b/tests/test_dwdweather.py
@@ -1,0 +1,18 @@
+import pytest
+
+from dwdweather.core import DwdWeather
+
+
+def test_dwdclass_init_no_args():
+    """
+    Test class can be initialized without arguments.
+    """
+    dw = DwdWeather()
+
+
+@pytest.mark.parametrize("resolution", ["hourly", "10_minutes"])
+def test_dwdclass_init(resolution):
+    """
+    Test class can be initialized with plausible resolutions.
+    """
+    dw = DwdWeather(resolution=resolution)


### PR DESCRIPTION
Currently, initializing the class per the readme, e.g.

```python
from datetime import datetime
from dwdweather import DwdWeather

# Create client object.
dw = DwdWeather()
```

results in an error. This PR fixes the issue and adds a test for the behavior.